### PR TITLE
Update writer.py

### DIFF
--- a/lesson-3-implementing-message-passing/grpc-demo/writer.py
+++ b/lesson-3-implementing-message-passing/grpc-demo/writer.py
@@ -14,7 +14,7 @@ stub = item_pb2_grpc.ItemServiceStub(channel)
 # Update this with desired payload
 item = item_pb2.ItemMessage(
     name="Non-Stick Frying Pan",
-    brand_name=10,
+    brand_name="Cuisinart",
     id=4,
     weight=4.5
 )


### PR DESCRIPTION
brand_name needs to be a string in order to follow udacity's videos with no errors. It is set as an integer in writer.py causing the error (TypeError: Cannot set ItemMessage.brand_name to 10: 10 has type <class 'int'>, but expected one of: (<class 'bytes'>, <class 'str'>) for field ItemMessage.brand_name)