### PR TITLE
fix example flask-demo and add a simple client

### DIFF
--- a/lesson-3-implementing-message-passing/flask-demo/app.py
+++ b/lesson-3-implementing-message-passing/flask-demo/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, Response, json
 
 from .services import retrieve_item, create_item
 
@@ -7,7 +7,7 @@ app = Flask(__name__)
 
 @app.route('/')
 def hello_world():
-    return 'Hello World!'
+    return jsonify({'message': 'Hello World!'})
 
 @app.route('/demo/<path_demo>', methods=['POST'])
 def demo(path_demo=None):
@@ -15,7 +15,7 @@ def demo(path_demo=None):
     path_value = path_demo
     header_value = request.headers.get('header_demo', None)
     param_value = request.args.get('param_demo', None)
-    body_value = request.data
+    body_value = request.data.decode('UTF-8')
     return {
         'result': {
             'path': path_value,
@@ -28,13 +28,12 @@ def demo(path_demo=None):
 @app.route('/api/items/<item_id>', methods=['GET', 'POST'])
 def pets(item_id):
     if request.method == 'GET':
-        return Response(json.dumps(retrieve_item(pet_id)), 200, {'Content-Type': 'application/json'})
+        return Response(json.dumps(retrieve_item(item_id)), 200, {'Content-Type': 'application/json'})
     elif request.method == 'POST':
         request_body = request.json
         return Response(json.dumps(create_item(item_id, request_body)))
     else:
         raise Exception('Unsupported HTTP request type.')
-
 
 if __name__ == '__main__':
     app.run()

--- a/lesson-3-implementing-message-passing/flask-demo/client.py
+++ b/lesson-3-implementing-message-passing/flask-demo/client.py
@@ -1,0 +1,23 @@
+import requests
+
+API_URL = "http://localhost:7111"
+
+# should return the default route"s output
+result = requests.get(API_URL)
+if result.status_code == 200:
+    print(result.json())
+
+# should return the demo path example
+result = requests.post(API_URL + "/demo/myPath?param_demo=myParam", json={"key": "value"}, headers={"header_demo": "myHeader"})
+if result.status_code == 200:
+    print(result.json())
+
+# should return the api example item
+result = requests.get(API_URL + "/api/items/1")
+if result.status_code == 200:
+    print(result.json())
+
+# should return the api example new item
+result = requests.post(API_URL + "/api/items/1", json={"name": "new_item"})
+if result.status_code == 200:
+    print(result.json())

--- a/lesson-3-implementing-message-passing/flask-demo/services.py
+++ b/lesson-3-implementing-message-passing/flask-demo/services.py
@@ -10,13 +10,11 @@ def retrieve_item(item_id):
     }
 
 
-def create_item(item_id):
+def create_item(item_id, request_body):
     """
     This is a stubbed method of creating a resource. It doesn't actually do anything.
     """
     return {
         "id": item_id,
-        "brand_name": "Clean Breathing",
-        "name": "Air Purifier",
-        "weight": 12.3,
+        "body": request_body,
     }


### PR DESCRIPTION
These changes fix the flask-demo, that contained several syntax errors. I will add further comments in the pull request. It also adds a simple client using the `request` package, that is mentioned in the course but never really shown.